### PR TITLE
Type changes for new Flutter (3.27.0)

### DIFF
--- a/lib/src/ndialogBase.dart
+++ b/lib/src/ndialogBase.dart
@@ -30,7 +30,7 @@ class NDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData? theme = Theme.of(context);
-    final DialogTheme? dialogTheme = DialogTheme.of(context);
+    final DialogThemeData dialogTheme = DialogTheme.of(context);
     final DialogStyle style = dialogStyle ?? DialogStyle();
 
     String? label = style.semanticsLabel;

--- a/lib/src/progressDialog.dart
+++ b/lib/src/progressDialog.dart
@@ -289,7 +289,7 @@ class _ProgressDialogWidgetState extends State<_ProgressDialogWidget>
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final DialogTheme dialogTheme = DialogTheme.of(context);
+    final DialogThemeData dialogTheme = DialogTheme.of(context);
 
     Widget? title = _title ?? widget.title;
     Widget message = _message ?? (widget.message ?? SizedBox.shrink());


### PR DESCRIPTION
Hey! I've got 
Error (Xcode): ../../../.pub-cache/hosted/pub.dev/ndialog-4.3.1/lib/src/ndialogBase.dart:33:50: Error: A value of type 'DialogThemeData' can't be assigned to a variable of type 'DialogTheme?'.

After I've upgraded to 3.27.0 Flutter. So, seems like just a type changes. Changed!